### PR TITLE
Add mosaic layouts for 5 and 7 tile matrices

### DIFF
--- a/index.html
+++ b/index.html
@@ -767,6 +767,38 @@ function openMatrix() {
 
   function applyLayout() {
     const n = Math.max(1, lastLive.length);
+    const tiles = matrixBody.children;
+
+    // Reset any previous explicit placement
+    Array.from(tiles).forEach(t => {
+      t.style.gridColumn = '';
+      t.style.gridRow = '';
+    });
+    matrixBody.style.gridTemplateColumns = '';
+    matrixBody.style.gridTemplateRows = '';
+
+    // Special mosaics for specific counts
+    if (n === 5) {
+      matrixBody.style.gridTemplateColumns = 'repeat(4, minmax(0, 1fr))';
+      matrixBody.style.gridTemplateRows = 'repeat(2, minmax(0, 1fr))';
+      if (tiles[0]) {
+        tiles[0].style.gridColumn = 'span 2';
+        tiles[0].style.gridRow = 'span 2';
+      }
+      return;
+    }
+
+    if (n === 7) {
+      matrixBody.style.gridTemplateColumns = 'repeat(5, minmax(0, 1fr))';
+      matrixBody.style.gridTemplateRows = 'repeat(2, minmax(0, 1fr))';
+      if (tiles[0]) {
+        tiles[0].style.gridColumn = 'span 2';
+        tiles[0].style.gridRow = 'span 2';
+      }
+      return;
+    }
+
+    // Default responsive layout
     const gap = parseFloat(getComputedStyle(matrixBody).gap || "8");
     const rect = matrixBody.getBoundingClientRect();
     const cols = optimalCols(n, rect.width, rect.height, gap || 8);


### PR DESCRIPTION
## Summary
- Customize `applyLayout` to use mosaic grids for 5 and 7 streams
- Reset grid placement and spans before layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add3eef3cc8332a4efdd752a27b12d